### PR TITLE
Table updates

### DIFF
--- a/src/jsMain/kotlin/app/softwork/bootstrapcompose/Button.kt
+++ b/src/jsMain/kotlin/app/softwork/bootstrapcompose/Button.kt
@@ -10,7 +10,9 @@ import org.w3c.dom.*
 public fun Button(
     title: String,
     color: Color = Color.Primary,
+    outlined: Boolean = false,
     type: ButtonType = ButtonType.Submit,
+    disabled: Boolean = false,
     styling: (Styling.() -> Unit)?=null,
     attrs: AttrBuilderContext<HTMLButtonElement>? = null,
     action: () -> Unit
@@ -20,7 +22,15 @@ public fun Button(
     } ?: arrayOf()
 
     Button(attrs = {
-        classes("btn", "btn-$color")
+        classes("btn")
+        if(outlined){
+            classes("btn-outline-$color")
+        }else{
+            classes("btn-$color")
+        }
+        if(disabled){
+            disabled()
+        }
         classes(*classes)
         attrs?.invoke(this)
         type(type)

--- a/src/jsMain/kotlin/app/softwork/bootstrapcompose/InputGroup.kt
+++ b/src/jsMain/kotlin/app/softwork/bootstrapcompose/InputGroup.kt
@@ -264,7 +264,7 @@ public class InputGroupContext(private val inputId: String) {
     @Composable
     public fun TextInput(
         value: String,
-        placeholder: String,
+        placeholder: String?=null,
         autocomplete: AutoComplete = AutoComplete.off,
         disabled: Boolean = false,
         styling: (Styling.() -> Unit)? = null,
@@ -275,9 +275,11 @@ public class InputGroupContext(private val inputId: String) {
             Styling().apply(it).generate()
         } ?: arrayOf()
 
-        TextInput(value) {
+        org.jetbrains.compose.web.dom.TextInput(value) {
             buildInputAttrs(disabled, autocomplete, classes, attrs, onInput)
-            placeholder(placeholder)
+            placeholder?.let{
+                placeholder(it)
+            }
         }
     }
 

--- a/src/jsMain/kotlin/app/softwork/bootstrapcompose/InputGroup.kt
+++ b/src/jsMain/kotlin/app/softwork/bootstrapcompose/InputGroup.kt
@@ -440,11 +440,12 @@ public class InputGroupContext(private val inputId: String) {
         title: String,
         color: Color = Color.Primary,
         type: ButtonType = ButtonType.Submit,
+        disabled: Boolean = false,
         styling: (Styling.() -> Unit)? = null,
         attrs: AttrBuilderContext<HTMLButtonElement>? = null,
         action: () -> Unit
     ) {
-        Button(title, color, type, styling, attrs, action)
+        Button(title, color, false, type, disabled, styling, attrs, action)
     }
 
     @Composable

--- a/src/jsMain/kotlin/app/softwork/bootstrapcompose/Table.kt
+++ b/src/jsMain/kotlin/app/softwork/bootstrapcompose/Table.kt
@@ -87,6 +87,7 @@ public fun <T> Table(
     fixedHeader: FixedHeaderProperty? = null,
     caption: ContentBuilder<HTMLTableCaptionElement>? = null,
     captionTop: Boolean = false,
+    attrs: AttrBuilderContext<HTMLTableElement>? = null,
     map: Builder.(Int, T) -> Unit
 ) {
     val headers = mutableMapOf<String, Header?>()
@@ -121,7 +122,8 @@ public fun <T> Table(
         captionTop = captionTop,
         headers = headers.toList(),
         footers = footers,
-        rows = rows
+        rows = rows,
+        attrs = attrs
     )
 }
 
@@ -143,6 +145,7 @@ public fun Table(
     headers: List<Pair<String, Header?>>,
     footers: List<Footer>? = null,
     rows: List<Row>,
+    attrs: AttrBuilderContext<HTMLTableElement>? = null,
 ) {
     Table(attrs = {
         classes("table")
@@ -162,6 +165,7 @@ public fun Table(
         if (borderless) {
             classes("table-borderless")
         }
+        attrs?.invoke(this)
     }) {
         if (caption != null) {
             Caption(content = caption)
@@ -176,8 +180,8 @@ public fun Table(
                             classes("table-$color")
                         }
                         if (fixedHeader != null) {
+                            classes("sticky-top")
                             style {
-                                position(Position.Sticky)
                                 top(fixedHeader.size)
                                 if (color == null) {
                                     background(fixedHeader.background.toString())


### PR DESCRIPTION
Added the sticky-top bootstrap class when using fixedHeader, which also sets z-index to 1020 and prevents some table content, like inputs, from rendering above the header when the table is scrolled.