### PR TITLE
Fix icons klib with empty source module

### DIFF
--- a/bootstrap-compose-icons/build.gradle.kts
+++ b/bootstrap-compose-icons/build.gradle.kts
@@ -27,11 +27,12 @@ kotlin {
 }
 tasks {
     val generateSVG by registering(app.softwork.bootstrapcompose.icons.ConvertSvg::class) {
+        dependsOn(rootProject.tasks.getByName("kotlinNpmInstall"))
         icons.set(rootProject.file("build/js/node_modules/bootstrap-icons/icons"))
         outputDir.set(File(project.buildDir, "generated/icons"))
         kotlin.sourceSets["main"].kotlin.srcDir(outputDir)
     }
-    assemble {
+    getByName("compileKotlinJs") {
         dependsOn(generateSVG)
     }
 }

--- a/buildSrc/src/main/kotlin/app/softwork/bootstrapcompose/icons/ConvertSvg.kt
+++ b/buildSrc/src/main/kotlin/app/softwork/bootstrapcompose/icons/ConvertSvg.kt
@@ -27,7 +27,9 @@ abstract class ConvertSvg : DefaultTask() {
         icons.asFileTree.forEachIndexed { index, file ->
             val name = file.nameWithoutExtension
             println("$index $name")
-            File(outputDir, "$name.kt")
+            val packageFile = File(outputDir, "app/softwork/bootstrapcompose/icons")
+            packageFile.mkdirs()
+            File(packageFile, "$name.kt")
                 .writeText(convertSvgToComposeSvg(file.readText(), name))
         }
     }


### PR DESCRIPTION
Using the icons published in 0.1.9 do not work, because the klib is empty.